### PR TITLE
remove default export from pages

### DIFF
--- a/src/pages/postcss.js
+++ b/src/pages/postcss.js
@@ -27,4 +27,4 @@ async function getFrontmatter(compilation, route, label, id) {
   };
 }
 
-export default { getFrontmatter, getBody };
+export { getFrontmatter, getBody };

--- a/src/pages/postcss2.js
+++ b/src/pages/postcss2.js
@@ -27,4 +27,4 @@ async function getFrontmatter(compilation, route, label, id) {
   };
 }
 
-export default { getFrontmatter, getBody };
+export { getFrontmatter, getBody };


### PR DESCRIPTION
resolves https://github.com/ProjectEvergreen/greenwood/discussions/1301#discussioncomment-11181767

Before all the exports were being defined as a _single_ `default` export.  Now they are individually exported as _named_ exports.  (this should work for the typescript branch as well)

With this change, the demo works locally 😃 
![Screenshot 2024-11-08 at 12 45 19 PM](https://github.com/user-attachments/assets/204fb31e-db8f-437c-8d63-fc3a4fd39d1a)